### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CustomNumberPicker(
               maxValue: 1000000,
               minValue: 0,
               step: 10000,
-              onValue: (value) {
+              onValue: (num value) {
                 print(value.toString());
               },
             )
@@ -82,7 +82,7 @@ class _MyAppState extends State<MyApp> {
               maxValue: 1000000,
               minValue: 0,
               step: 10000,
-              onValue: (value) {
+              onValue: (num value) {
                 print(value.toString());
               },
             ),


### PR DESCRIPTION
If we use just (value) an exception is thrown
type '(int) => Null' is not a subtype of type '(num) => dynamic'